### PR TITLE
Streamline responsive layout for skills and work

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,42 +130,35 @@ master's degree in computer science with a focus on AI, honing skills, and stayi
     </div>
     <div style="color: #DDDDDD;">*</div>
   </div>
-  <div class="container-fluid text-center" id="skill">
+    <div class="container-fluid text-center" id="skill">
     <p class="text-dark mt-3 fs-h1">Technical Skills</p>
-    <div class="row column-lg">
-      <div class="col-md-2"></div>
-      <div class="col-md-4 border-end border-dark">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-4 border-lg-end border-dark">
         <p class="text-dark text-center fs-4 ff-p fw-bold">Backend Languages</p>
         <img class="mx-2 mt-3 mb-3" src="images/python.png" alt="Python" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/java.png" alt="Java" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/c-.png" alt="C" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/letter-c.png" alt="C++" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/sql-server.png" alt="SQL" width="70" height="70" />
-    
         <img class="mx-2 mt-3 mb-3" src="images/nodejs.png" alt="NodeJS" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/express.png" alt="Express" width="70" height="20" />
         <img class="mx-2 mt-3 mb-3" src="images/flask.png" alt="Flask" width="70" height="70" />
       </div>
-      <div class="col-md-4 border-start border-dark">
-        <p class="text-dark text-center fs-4 fw-bold fw-bold ff-p">Frontend Languages</p>
+      <div class="col-12 col-lg-4 border-lg-start border-dark">
+        <p class="text-dark text-center fs-4 fw-bold ff-p">Frontend Languages</p>
         <img class="mx-2 mt-3 mb-3" src="images/html-5.png" alt="HTML" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/css.png" alt="CSS" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/java-script.png" alt="JavaScript" width="70" height="70" />
-        
         <img class="mx-2 mt-3 mb-3" src="images/typescript.png" alt="TypeScript" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/angular.png" alt="AngularJS" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/bootstrap.png" alt="Bootstrap" width="170" height="70" />
-
       </div>
-      <div class="col-md-2"></div>
-    </div>
-    <div class="mt-1 mb-1 column-lg">
-      <hr class="mx-auto hrule" />
-    </div>
-    <div class="row column-lg">
-      <div class="col-md-2"></div>
-      <div class="col-md-4 border-end border-dark">
-        <p class="text-dark text-center fs-4 fw-bold fw-bold ff-p">Platforms</p>
+      <div class="col-12 my-3">
+        <hr class="mx-auto hrule d-lg-none" />
+        <hr class="mx-auto hrule d-none d-lg-block" />
+      </div>
+      <div class="col-12 col-lg-4 border-lg-end border-dark">
+        <p class="text-dark text-center fs-4 fw-bold ff-p">Platforms</p>
         <img class="mx-2 mt-3 mb-3" src="images/gcp.png" alt="GCP" width="130" height="90" />
         <img class="mx-2 mt-3 mb-3" src="images/aws.png" alt="AWS" width="50" height="50" />
         <img class="mx-2 mt-3 mb-3" src="Images/github.png" alt="GitHub" width="60" height="60" />
@@ -173,8 +166,8 @@ master's degree in computer science with a focus on AI, honing skills, and stayi
         <img class="mx-2 mt-3 mb-3" src="images/vmware.png" alt="vmware" width="60" height="60" />
         <img class="mx-2 mt-3 mb-3" src="images/kvm.png" alt="kvm" width="70" height="70" />
       </div>
-      <div class="col-md-4 border-start border-dark">
-        <p class="text-dark text-center fs-4 fw-bold fw-bold ff-p">Tools</p>
+      <div class="col-12 col-lg-4 border-lg-start border-dark">
+        <p class="text-dark text-center fs-4 fw-bold ff-p">Tools</p>
         <img class="mx-2 mt-3 mb-3" src="images/jupyter.png" alt="Jupyter" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/vs_code.png" alt="VS Code" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/xcode.png" alt="Xcode" width="70" height="70" />
@@ -182,15 +175,12 @@ master's degree in computer science with a focus on AI, honing skills, and stayi
         <img class="mx-2 mt-3 mb-3" src="images/jira.png" alt="Jira" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/eclipse.png" alt="Eclipse" width="130" height="40" />
       </div>
-      <div class="col-md-2"></div>
-    </div>
-        <div class="mt-1 mb-1 column-lg">
-      <hr class="mx-auto hrule" />
-    </div>
-        <div class="row column-lg">
-      <div class="col-md-2"></div>
-      <div class="col-md-4 border-end border-dark">
-        <p class="text-dark text-center fs-4 fw-bold fw-bold ff-p">Machine Learning</p>
+      <div class="col-12 my-3">
+        <hr class="mx-auto hrule d-lg-none" />
+        <hr class="mx-auto hrule d-none d-lg-block" />
+      </div>
+      <div class="col-12 col-lg-4 border-lg-end border-dark">
+        <p class="text-dark text-center fs-4 fw-bold ff-p">Machine Learning</p>
         <img class="mx-2 mt-3 mb-3" src="images/tensorflow.png" alt="TensorFlow" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/Pytorch.png" alt="PyTorch" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/scikit.png" alt="ScikitLearn" width="70" height="70" />
@@ -198,8 +188,8 @@ master's degree in computer science with a focus on AI, honing skills, and stayi
         <img class="mx-2 mt-3 mb-3" src="images/matplotlib.png" alt="Matplotlib" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/seaborn.png" alt="Seaborn" width="70" height="70" />
       </div>
-      <div class="col-md-4 border-start border-dark">
-        <p class="text-dark text-center fs-4 fw-bold fw-bold ff-p">NLP</p>
+      <div class="col-12 col-lg-4 border-lg-start border-dark">
+        <p class="text-dark text-center fs-4 fw-bold ff-p">NLP</p>
         <img class="mx-2 mt-3 mb-3" src="images/huggingface.png" alt="Hugging Face Transformer" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/nltk.png" alt="NLTK" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/Keras.png" alt="Keras" width="70" height="70" />
@@ -207,119 +197,25 @@ master's degree in computer science with a focus on AI, honing skills, and stayi
         <img class="mx-2 mt-3 mb-3" src="images/pandas.png" alt="Panda" width="70" height="70" />
         <img class="mx-2 mt-3 mb-3" src="images/nump.png" alt="Numpy" width="70" height="70" />
       </div>
-      <div class="col-md-2"></div>
     </div>
     <div style="color: #DDDDDD;">*</div>
-    <div class="row column-sm w-75 mx-auto">
-      <div class="col-sm-12">
-        <p class="text-dark text-center ff-p fw-bold">Backend Languages</p>
-        <img class="mx-2 mt-3 mb-3" src="images/python.png" alt="Python" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/java.png" alt="Java" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/c-.png" alt="C" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/letter-c.png" alt="C++" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/sql-server.png" alt="SQL" width="150" height="150" />
-        
-        <img class="mx-2 mt-3 mb-3" src="images/nodejs.png" alt="NodeJS" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/express.png" alt="Express" width="200" height="50" />
-        <img class="mx-2 mt-3 mb-3" src="images/flask.png" alt="Flask" width="150" height="150" />
-      </div>
-      <div class="mt-1 mb-1">
-        <hr class="mx-auto hrule" />
-      </div>
-      <div class="col-sm-12 mt-5">
-        <p class="text-dark text-center fw-bold fw-bold ff-p">Frontend Languages</p>
-        <img class="mx-2 mt-3 mb-3" src="images/html-5.png" alt="HTML" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/css.png" alt="CSS" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/java-script.png" alt="JavaScript" width="150" height="150" />
-   
-        <img class="mx-2 mt-3 mb-3" src="images/typescript.png" alt="TypeScript" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/angular.png" alt="AngularJS" width="150" height="150" />
-        <img class="mx-2 mt-3 mb-3" src="images/bootstrap.png" alt="Bootstrap" width="400" height="150" />
-       
-      </div>
-      <div class="mt-1 mb-1">
-        <hr class="mx-auto hrule" />
-      </div>
-      <div class="col-sm-12 mt-5">
-        <p class="text-dark text-center fw-bold fw-bold ff-p">Platforms</p>
-        <img class="mx-2 mt-3 mb-3" src="images/gcp.png" alt="GCP" width="130" height="90" />
-        <img class="mx-2 mt-3 mb-3" src="images/aws.png" alt="AWS" width="50" height="50" />
-        <img class="mx-2 mt-3 mb-3" src="Images/github.png" alt="GitHub" width="60" height="60" />
-        <img class="mx-2 mt-3 mb-3" src="images/docker.png" alt="Docker" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/vmware.png" alt="vmware" width="60" height="60" />
-        <img class="mx-2 mt-3 mb-3" src="images/kvm.png" alt="kvm" width="70" height="70" />
-      </div>
-      <div class="mt-1 mb-1">
-        <hr class="mx-auto hrule" />
-      </div>
-      <div class="col-sm-12 mt-5">
-        <p class="text-dark text-center fw-bold fw-bold ff-p">Tools</p>
-        <img class="mx-2 mt-3 mb-3" src="images/jupyter.png" alt="Jupyter" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/vs_code.png" alt="VS Code" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/xcode.png" alt="Xcode" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/colab.png" alt="Google Colab" width="90" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/jira.png" alt="Jira" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/eclipse.png" alt="Eclipse" width="130" height="40" />
-      </div>
-            <div class="mt-1 mb-1">
-        <hr class="mx-auto hrule" />
-      </div>
-      <div class="col-sm-12 mt-5">
-        <p class="text-dark text-center fw-bold fw-bold ff-p">Machine Learning</p>
-        <img class="mx-2 mt-3 mb-3" src="images/tensorflow.png" alt="TensorFlow" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/Pytorch.png" alt="PyTorch" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/scikit.png" alt="ScikitLearn" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/xgboost.png" alt="XGBoost" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/matplotlib.png" alt="Matplotlib" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/seaborn.png" alt="Seaborn" width="70" height="70" />
-      </div>
-      <div class="mt-1 mb-1">
-        <hr class="mx-auto hrule" />
-      </div>
-      <div class="col-sm-12 mt-5">
-        <p class="text-dark text-center fw-bold fw-bold ff-p">NLP</p>
-        <img class="mx-2 mt-3 mb-3" src="images/huggingface.png" alt="Hugging Face Transformer" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/nltk.png" alt="NLTK" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/Keras.png" alt="Keras" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/gensim.png" alt="Gensim" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/pandas.png" alt="Panda" width="70" height="70" />
-        <img class="mx-2 mt-3 mb-3" src="images/nump.png" alt="Numpy" width="70" height="70" />
-      </div>
-    </div>
   </div>
-  <div class="container-fluid text-center bg-clr" id="work">
+    <div class="container-fluid text-center bg-clr" id="work">
     <p class="text-dark mt-3 fs-h1">Work Experience</p>
-<div class="row column-lg">
-  <div class="col-md-12">
-    <p class="text-danger text-center fs-4 fw-bold ff-p">2024</p>
-  </div>
-</div>
-<div class="row column-lg">
-  <div class="col-md-2"></div>
-  <div class="col-md-4 border-end border-dark">
-    <div class="card bg-dark border border-secondary mx-auto card-pro-top">
-        <div class="card-body">
-          <p class="card-text text-white text-center fw-bold ff-p">Ribbon Communications</p>
-          <p class="card-text text-orange ff-p">Senior Engineering Technical Analyst</p>
-          <p class="card-text text-orange ff-p">Apr 2024 – Jun 2024</p>
-          <p class="text-end mb-0"><a class="card-text text-warning ff-p text-decoration-none" onclick="show_modal('seta')">Read More ></a></p>
-        </div>
-    </div>
-  </div>
-  <div class="col-md-4 border-start border-dark">
-  </div>
-  <div class="col-md-2"></div>
-</div>
-    <div class="row column-lg">
-      <div class="col-md-12">
+    <div class="row row-cols-1 row-cols-lg-2 g-4 justify-content-center">
+      <div class="col">
         <p class="text-danger text-center fs-4 fw-bold ff-p">2024</p>
+        <div class="card bg-dark border border-secondary mx-auto card-pro-top">
+            <div class="card-body">
+              <p class="card-text text-white text-center fw-bold ff-p">Ribbon Communications</p>
+              <p class="card-text text-orange ff-p">Senior Engineering Technical Analyst</p>
+              <p class="card-text text-orange ff-p">Apr 2024 – Jun 2024</p>
+              <p class="text-end mb-0"><a class="card-text text-warning ff-p text-decoration-none" onclick="show_modal('seta')">Read More ></a></p>
+            </div>
+        </div>
       </div>
-    </div>
-    <div class="row column-lg">
-      <div class="col-md-2"></div>
-      <div class="col-md-4 border-end border-dark">
-      </div>
-      <div class="col-md-4 border-start border-dark">
+      <div class="col">
+        <p class="text-danger text-center fs-4 fw-bold ff-p">2021</p>
         <div class="card bg-dark border border-secondary mx-auto card-pro-top">
             <div class="card-body">
               <p class="card-text text-white text-center fw-bold ff-p">Ribbon Communications</p>
@@ -329,102 +225,10 @@ master's degree in computer science with a focus on AI, honing skills, and stayi
             </div>
         </div>
       </div>
-      <div class="col-md-2"></div>
-    </div>
-    <div class="row column-lg">
-      <div class="col-md-12">
-        <p class="text-danger text-center fs-4 fw-bold ff-p">2021</p>
-      </div>
-    </div>
-    <div class="row column-sm">
-      <div class="col-sm-6 border-end border-dark">
-        <p style="color: #DDDDDD;">*</p>
-      </div>
-      <div class="col-sm-6 border-start border-dark">
-        <p style="color: #DDDDDD;">*</p>
-      </div>
-    </div>
-<div class="row column-sm">
-  <div class="col-sm-12">
-    <p class="text-dark text-center fw-bold ff-p">2024</p>
-  </div>
-</div>
-<div class="row column-sm">
-  <div class="col-sm-6 border-end border-dark">
-    <p style="color: #DDDDDD;">*</p>
-  </div>
-  <div class="col-sm-6 border-start border-dark">
-    <p style="color: #DDDDDD;">*</p>
-  </div>
-</div>
-<div class="row column-sm">
-  <div class="col-sm-12">
-    <div class="card bg-dark border border-secondary mx-auto card-img-top">
-        <div class="card-body">
-          <p class="card-text text-white text-center fw-bold ff-p">Ribbon Communications</p>
-          <p class="card-text text-orange ff-p">Senior Engineering Technical Analyst</p>
-          <p class="card-text text-orange ff-p">Apr 2024 – Jun 2024</p>
-          <p class="text-end mb-0"><a class="card-text text-warning ff-p text-decoration-none" onclick="show_modal('seta')">Read More ></a></p>
-        </div>
-    </div>
-  </div>
-</div>
-<div class="row column-sm">
-  <div class="col-sm-6 border-end border-dark">
-    <p style="color: #DDDDDD;">*</p>
-  </div>
-  <div class="col-sm-6 border-start border-dark">
-    <p style="color: #DDDDDD;">*</p>
-  </div>
-</div>
-        <div class="row column-sm">
-      <div class="col-sm-12">
-        <p class="text-dark text-center fw-bold ff-p">2021</p>
-      </div>
-    </div>
-    <div class="row column-sm">
-      <div class="col-sm-6 border-end border-dark">
-        <p style="color: #DDDDDD;">*</p>
-      </div>
-      <div class="col-sm-6 border-start border-dark">
-        <p style="color: #DDDDDD;">*</p>
-      </div>
-    </div>
-    <div class="row column-sm">
-      <div class="col-sm-12">
-        <div class="card bg-dark border border-secondary mx-auto card-img-top">
-            <div class="card-body">
-              <p class="card-text text-white text-center fw-bold ff-p">Ribbon Communications</p>
-              <p class="card-text text-orange ff-p">Engineering Technical Analyst</p>
-              <p class="card-text text-orange ff-p">Aug 2021 – Mar 2024</p>
-              <p class="text-end mb-0"><a class="card-text text-warning ff-p text-decoration-none" onclick="show_modal('eta')">Read More ></a></p>
-            </div>
-        </div>
-      </div>
-    </div>
-    <div class="row column-sm">
-      <div class="col-sm-6 border-end border-dark">
-        <p style="color: #DDDDDD;">*</p>
-      </div>
-      <div class="col-sm-6 border-start border-dark">
-        <p style="color: #DDDDDD;">*</p>
-      </div>
-    <div class="row column-sm">
-      <div class="col-sm-6 border-end border-dark">
-        <p style="color: #DDDDDD;">*</p>
-      </div>
-      <div class="col-sm-6 border-start border-dark">
-        <p style="color: #DDDDDD;">*</p>
-      </div>
-    </div>
-        <div class="row column-sm">
-       <div class="col-sm-12">
-          <p class="text-dark text-center fw-bold ff-p">2014</p>
-      </div>
     </div>
     <div style="color: #DDDDDD;">*</div>
   </div>
-<div class="modal fade" id="seta" tabindex="-1" role="dialog">
+  <div class="modal fade" id="seta" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content bg-dark text-left">
       <div class="modal-header">


### PR DESCRIPTION
## Summary
- Replace duplicated skill markup with a single responsive grid using Bootstrap utilities
- Consolidate work section into one block and display entries responsively

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e9f2a60a88331ab494bc6f642fb2f